### PR TITLE
Implement interactive settings menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys
 from dog_park import draw_dog_park
 from inventory import draw_inventory
 from chat import draw_chat, update_chat
-from settings import draw_settings
+from settings import draw_settings, handle_settings_event
 from birdie import draw_birdie
 
 pygame.init()
@@ -49,15 +49,17 @@ while running:
                     state = menu_options[selected]
             else:
                 if event.key in [pygame.K_RETURN, pygame.K_SPACE]:
-                    state = "menu"
                     if state == "Chat":
                         chat_scroll = 0
+                    state = "menu"
                 elif state == "Chat":
                     # Pass arrow key events for scrolling
                     if event.key == pygame.K_UP:
                         chat_scroll += 1
                     elif event.key == pygame.K_DOWN:
                         chat_scroll -= 1
+                elif state == "Settings":
+                    handle_settings_event(event)
 
     # Draw current screen
     if state == "menu":

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,52 @@
+"""Interactive settings screen."""
+
+import pygame
+
+# Available settings with default values
+settings_options = [
+    {"name": "Sound", "type": "bool", "value": True},
+    {"name": "Difficulty", "type": ["Easy", "Normal", "Hard"], "value": "Normal"},
+    {"name": "Show Tips", "type": "bool", "value": True},
+]
+
+# Index of the currently selected setting
+selected_option = 0
+
+
+def handle_settings_event(event):
+    """Handle key input when the settings screen is active."""
+    global selected_option
+
+    if event.key == pygame.K_UP:
+        selected_option = (selected_option - 1) % len(settings_options)
+    elif event.key == pygame.K_DOWN:
+        selected_option = (selected_option + 1) % len(settings_options)
+    elif event.key in (pygame.K_LEFT, pygame.K_RIGHT, pygame.K_SPACE):
+        option = settings_options[selected_option]
+        if option["type"] == "bool":
+            option["value"] = not option["value"]
+        else:
+            choices = option["type"]
+            idx = choices.index(option["value"])
+            if event.key == pygame.K_LEFT:
+                idx = (idx - 1) % len(choices)
+            else:
+                idx = (idx + 1) % len(choices)
+            option["value"] = choices[idx]
+
+
 def draw_settings(screen, FONT):
+    """Render the settings menu to ``screen`` using ``FONT``."""
     screen.fill((80, 80, 120))
-    msg = FONT.render("Settings (placeholder)", True, (255,255,255))
-    screen.blit(msg, (8, 54))
-    tip = FONT.render("Press joystick to return", True, (200,220,255))
+
+    title = FONT.render("Settings", True, (255, 255, 255))
+    screen.blit(title, (6, 4))
+
+    for i, option in enumerate(settings_options):
+        color = (200, 255, 200) if i == selected_option else (255, 255, 255)
+        text = f"{option['name']}: {option['value']}"
+        msg = FONT.render(text, True, color)
+        screen.blit(msg, (6, 24 + i * 16))
+
+    tip = FONT.render("Arrows=Change  Enter=Back", True, (200, 220, 255))
     screen.blit(tip, (6, 114))


### PR DESCRIPTION
## Summary
- add a navigable settings screen with a few options
- allow arrow/space keys to change settings
- handle settings events from the main loop

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails: XDG runtime dir / ALSA errors)*

------
https://chatgpt.com/codex/tasks/task_e_684632606dcc832f8a9971bcbcb7f51a