### PR TITLE
Enable menu scrolling and hold-to-move pong paddle

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,8 @@ BLACK = (0,0,0)
 
 menu_options = ["Birdie", "Dog Park", "Inventory", "Chat", "Settings", "Snake", "Pong"]
 selected = 0
+menu_scroll = 0
+MAX_VISIBLE = 6
 state = "menu"
 
 clock = pygame.time.Clock()
@@ -47,6 +49,11 @@ while running:
                         selected = (selected - 1) % len(menu_options)
                     else:
                         selected = (selected + 1) % len(menu_options)
+                    if selected < menu_scroll:
+                        menu_scroll = selected
+                    elif selected >= menu_scroll + MAX_VISIBLE:
+                        menu_scroll = selected - MAX_VISIBLE + 1
+                    menu_scroll = max(0, min(menu_scroll, len(menu_options) - MAX_VISIBLE))
                 elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
                     state = menu_options[selected]
             else:
@@ -66,16 +73,21 @@ while running:
                     handle_snake_event(event)
                 elif state == "Pong":
                     handle_pong_event(event)
+        elif event.type == pygame.KEYUP:
+            if state == "Pong":
+                handle_pong_event(event)
 
     # Draw current screen
     if state == "menu":
         screen.fill((120, 180, 255))
         title = BIGFONT.render("Main Menu", True, BLACK)
         screen.blit(title, (10, 5))
-        for i, option in enumerate(menu_options):
+        visible_options = menu_options[menu_scroll:menu_scroll + MAX_VISIBLE]
+        for idx, option in enumerate(visible_options):
+            i = menu_scroll + idx
             color = (50,100,255) if i == selected else BLACK
             text = FONT.render(option, True, color)
-            screen.blit(text, (20, 28 + i*16))
+            screen.blit(text, (20, 28 + idx*16))
     elif state == "Dog Park":
         draw_dog_park(screen, FONT)
     elif state == "Inventory":

--- a/pong.py
+++ b/pong.py
@@ -8,6 +8,7 @@ PLAYER_X = 4
 AI_X = WIDTH - PADDLE_W - 4
 
 player_y = HEIGHT // 2 - PADDLE_H // 2
+player_move = 0
 ai_y = HEIGHT // 2 - PADDLE_H // 2
 ball_pos = [WIDTH // 2, HEIGHT // 2]
 ball_vel = [2, 2]
@@ -25,18 +26,25 @@ reset_pong()
 
 
 def handle_pong_event(event):
-    """Move the player paddle."""
-    global player_y
-    if event.key == pygame.K_UP:
-        player_y -= 4
-    elif event.key == pygame.K_DOWN:
-        player_y += 4
-    player_y = max(0, min(HEIGHT - PADDLE_H, player_y))
+    """Start or stop moving the player paddle based on key events."""
+    global player_move
+    if event.type == pygame.KEYDOWN:
+        if event.key == pygame.K_UP:
+            player_move = -4
+        elif event.key == pygame.K_DOWN:
+            player_move = 4
+    elif event.type == pygame.KEYUP:
+        if event.key in (pygame.K_UP, pygame.K_DOWN):
+            player_move = 0
 
 
 def update_pong(now):
     """Update pong game state."""
-    global ball_pos, ball_vel, ai_y
+    global ball_pos, ball_vel, ai_y, player_y
+
+    # Move player paddle continuously
+    player_y += player_move
+    player_y = max(0, min(HEIGHT - PADDLE_H, player_y))
 
     # Move ball
     ball_pos[0] += ball_vel[0]


### PR DESCRIPTION
## Summary
- scroll menu when selection moves beyond visible range
- support holding arrow keys in Pong

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846370801d4832fa641296c231bf4d4