### PR TITLE
Add typing test screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from settings import draw_settings, handle_settings_event
 from birdie import draw_birdie
 from snake import draw_snake, update_snake, handle_snake_event
 from pong import draw_pong, update_pong, handle_pong_event
+from typer import draw_type, handle_type_event
 
 pygame.init()
 SIZE = 128
@@ -19,7 +20,7 @@ BIGFONT = pygame.font.SysFont("monospace", 15)
 WHITE = (255,255,255)
 BLACK = (0,0,0)
 
-menu_options = ["Birdie", "Dog Park", "Inventory", "Chat", "Settings", "Snake", "Pong"]
+menu_options = ["Birdie", "Dog Park", "Inventory", "Chat", "Settings", "Snake", "Pong", "Type"]
 selected = 0
 menu_scroll = 0
 MAX_VISIBLE = 6
@@ -57,7 +58,12 @@ while running:
                 elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
                     state = menu_options[selected]
             else:
-                if event.key in [pygame.K_RETURN, pygame.K_SPACE]:
+                if state == "Type":
+                    if event.key == pygame.K_ESCAPE:
+                        state = "menu"
+                    else:
+                        handle_type_event(event)
+                elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
                     if state == "Chat":
                         chat_scroll = 0
                     state = "menu"
@@ -105,6 +111,8 @@ while running:
     elif state == "Pong":
         update_pong(now)
         draw_pong(screen, FONT)
+    elif state == "Type":
+        draw_type(screen, FONT)
 
     pygame.display.flip()
     clock.tick(30)

--- a/typer.py
+++ b/typer.py
@@ -1,0 +1,53 @@
+import pygame
+
+keyboard_chars = list("abcdefghijklmnopqrstuvwxyz0123456789.,!? ")
+VISIBLE = 10
+cursor = 0
+scroll = 0
+typed_text = ""
+shift = False
+
+
+def handle_type_event(event):
+    global cursor, scroll, typed_text, shift
+    if event.key == pygame.K_LEFT:
+        cursor = (cursor - 1) % len(keyboard_chars)
+    elif event.key == pygame.K_RIGHT:
+        cursor = (cursor + 1) % len(keyboard_chars)
+    elif event.key == pygame.K_UP:
+        ch = keyboard_chars[cursor]
+        if shift:
+            ch = ch.upper()
+            shift = False
+        typed_text += ch
+        if len(typed_text) > 60:
+            typed_text = typed_text[-60:]
+    elif event.key == pygame.K_DOWN:
+        typed_text = typed_text[:-1]
+    elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+        shift = not shift
+
+    if cursor < scroll:
+        scroll = cursor
+    elif cursor >= scroll + VISIBLE:
+        scroll = cursor - VISIBLE + 1
+
+
+def draw_type(screen, FONT):
+    screen.fill((30, 30, 30))
+    display = typed_text[-16:]
+    msg = FONT.render(display, True, (255, 255, 255))
+    screen.blit(msg, (4, 40))
+
+    start = scroll
+    end = scroll + VISIBLE
+    for i, ch in enumerate(keyboard_chars[start:end]):
+        idx = start + i
+        color = (255, 255, 0) if idx == cursor else (200, 200, 200)
+        disp_ch = ch.upper() if shift else ch
+        text = FONT.render(disp_ch, True, color)
+        x = 6 + i * 12
+        screen.blit(text, (x, 92))
+
+    tip = FONT.render("LR Move U=Sel D=Del ENT=Shift ESC=Back", True, (200, 200, 200))
+    screen.blit(tip, (2, 114))


### PR DESCRIPTION
## Summary
- create `typer.py` implementing a simple scrolling keyboard and text display
- add new `Type` option to the main menu
- handle keyboard interaction and drawing of the Type screen

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68463a1ce124832f8af29247f7165609