### PR TITLE
Add Battle feature

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -1,0 +1,112 @@
+import pygame
+import random
+
+# Options for the initial battle menu
+BATTLE_OPTIONS = ["Practice", "GameLink"]
+selected_option = 0
+
+# Battle state variables for practice battles
+PLAYER_MAX_HP = 50
+ENEMY_MIN_HP = 30
+ENEMY_MAX_HP = 60
+player_hp = PLAYER_MAX_HP
+enemy_hp = ENEMY_MAX_HP
+message = ""
+battle_over = False
+
+
+def handle_battle_menu_event(event):
+    """Handle up/down/select events in the battle menu."""
+    global selected_option
+    if event.key == pygame.K_UP:
+        selected_option = (selected_option - 1) % len(BATTLE_OPTIONS)
+    elif event.key == pygame.K_DOWN:
+        selected_option = (selected_option + 1) % len(BATTLE_OPTIONS)
+    elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+        return BATTLE_OPTIONS[selected_option]
+    return None
+
+
+def draw_battle_menu(screen, FONT):
+    """Draw the battle selection menu."""
+    screen.fill((40, 60, 90))
+    title = FONT.render("Battle", True, (255, 255, 255))
+    screen.blit(title, (6, 4))
+    for i, option in enumerate(BATTLE_OPTIONS):
+        color = (200, 255, 200) if i == selected_option else (255, 255, 255)
+        msg = FONT.render(option, True, color)
+        screen.blit(msg, (6, 24 + i * 16))
+    tip = FONT.render("Enter=Select Esc=Back", True, (200, 220, 255))
+    screen.blit(tip, (6, 114))
+
+
+def start_practice_battle():
+    """Initialise practice battle state."""
+    global player_hp, enemy_hp, message, battle_over
+    player_hp = PLAYER_MAX_HP
+    enemy_hp = random.randint(ENEMY_MIN_HP, ENEMY_MAX_HP)
+    message = "A wild pet appeared!"
+    battle_over = False
+
+
+def handle_practice_event(event):
+    """Handle key input during a practice battle.
+
+    Returns True when the battle should exit back to the battle menu.
+    """
+    global player_hp, enemy_hp, message, battle_over
+    if battle_over:
+        if event.key in (pygame.K_RETURN, pygame.K_SPACE, pygame.K_ESCAPE):
+            return True
+        return False
+    if event.key == pygame.K_ESCAPE:
+        return True
+    if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+        damage = random.randint(5, 12)
+        enemy_hp -= damage
+        message = f"You hit! {damage} dmg"
+        if enemy_hp <= 0:
+            battle_over = True
+            message = "You won!"
+            return False
+        enemy_damage = random.randint(5, 12)
+        player_hp -= enemy_damage
+        message += f" Enemy hits {enemy_damage}"
+        if player_hp <= 0:
+            battle_over = True
+            message += " - You lost!"
+    return False
+
+
+def draw_practice_battle(screen, FONT):
+    """Render the practice battle to ``screen`` using ``FONT``."""
+    screen.fill((0, 0, 0))
+    ph = FONT.render(f"Your HP: {player_hp}", True, (255, 255, 255))
+    eh = FONT.render(f"Enemy HP: {enemy_hp}", True, (255, 255, 255))
+    screen.blit(ph, (6, 20))
+    screen.blit(eh, (6, 36))
+    msg = FONT.render(message, True, (255, 255, 0))
+    screen.blit(msg, (6, 60))
+    if battle_over:
+        tip = FONT.render("Enter=Back", True, (200, 220, 255))
+    else:
+        tip = FONT.render("Enter=Attack Esc=Run", True, (200, 220, 255))
+    screen.blit(tip, (6, 114))
+
+
+def handle_gamelink_event(event):
+    """Handle input for the GameLink placeholder screen."""
+    if event.key in (pygame.K_RETURN, pygame.K_SPACE, pygame.K_ESCAPE):
+        return True
+    return False
+
+
+def draw_gamelink(screen, FONT):
+    """Draw placeholder GameLink screen."""
+    screen.fill((20, 30, 50))
+    msg1 = FONT.render("GameLink (Bluetooth)", True, (255, 255, 255))
+    msg2 = FONT.render("Not implemented", True, (255, 255, 255))
+    screen.blit(msg1, (6, 50))
+    screen.blit(msg2, (6, 66))
+    tip = FONT.render("Enter=Back", True, (200, 220, 255))
+    screen.blit(tip, (6, 114))

--- a/main.py
+++ b/main.py
@@ -9,6 +9,15 @@ from snake import draw_snake, update_snake, handle_snake_event
 from pong import draw_pong, update_pong, handle_pong_event
 from tetris import draw_tetris, update_tetris, handle_tetris_event, reset_tetris
 from typer import draw_type, handle_type_event
+from battle import (
+    draw_battle_menu,
+    handle_battle_menu_event,
+    start_practice_battle,
+    draw_practice_battle,
+    handle_practice_event,
+    draw_gamelink,
+    handle_gamelink_event,
+)
 
 pygame.init()
 SIZE = 128
@@ -21,7 +30,18 @@ BIGFONT = pygame.font.SysFont("monospace", 15)
 WHITE = (255,255,255)
 BLACK = (0,0,0)
 
-menu_options = ["Birdie", "Dog Park", "Inventory", "Chat", "Settings", "Snake", "Pong", "Tetris", "Type"]
+menu_options = [
+    "Birdie",
+    "Dog Park",
+    "Inventory",
+    "Chat",
+    "Settings",
+    "Battle",
+    "Snake",
+    "Pong",
+    "Tetris",
+    "Type",
+]
 selected = 0
 menu_scroll = 0
 MAX_VISIBLE = 6
@@ -64,6 +84,21 @@ while running:
                         state = "menu"
                     else:
                         handle_type_event(event)
+                elif state == "Battle":
+                    selection = handle_battle_menu_event(event)
+                    if selection == "Practice":
+                        start_practice_battle()
+                        state = "BattlePractice"
+                    elif selection == "GameLink":
+                        state = "BattleGameLink"
+                    elif event.key == pygame.K_ESCAPE:
+                        state = "menu"
+                elif state == "BattlePractice":
+                    if handle_practice_event(event):
+                        state = "Battle"
+                elif state == "BattleGameLink":
+                    if handle_gamelink_event(event):
+                        state = "Battle"
                 elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
                     if state == "Chat":
                         chat_scroll = 0
@@ -108,6 +143,12 @@ while running:
         draw_settings(screen, FONT)
     elif state == "Birdie":
         draw_birdie(screen, FONT)
+    elif state == "Battle":
+        draw_battle_menu(screen, FONT)
+    elif state == "BattlePractice":
+        draw_practice_battle(screen, FONT)
+    elif state == "BattleGameLink":
+        draw_gamelink(screen, FONT)
     elif state == "Snake":
         update_snake(now)
         draw_snake(screen, FONT)


### PR DESCRIPTION
## Summary
- add new `battle.py` module implementing simple practice battle and GameLink placeholder
- integrate battle feature into main menu with `Battle`, `Practice`, and `GameLink` states

## Testing
- `python -m py_compile *.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464dd2fff0832fa330a434b230f25a