### PR TITLE
Fix audio init crash and reduce logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,14 +28,19 @@ from battle import (
 )
 
 pygame.init()
-pygame.mixer.init()
+try:
+    pygame.mixer.init()
+    SOUND_AVAILABLE = True
+except Exception:
+    SOUND_AVAILABLE = False
+    print("Warning: Audio disabled")
 SIZE = 128
 screen = pygame.display.set_mode((SIZE, SIZE))
 pygame.display.set_caption("Virtual Pet Menu Prototype")
 
 # Set up logging to both console and file
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.FileHandler("log.txt"),
@@ -178,13 +183,14 @@ try:
         # Handle entering or leaving Tetris state
         if state != old_state:
             if state == "Tetris":
-                try:
-                    pygame.mixer.music.load(TETRIS_MUSIC)
-                    pygame.mixer.music.play(-1)
-                except Exception:
-                    logger.exception("Failed to play Tetris music")
+                if SOUND_AVAILABLE:
+                    try:
+                        pygame.mixer.music.load(TETRIS_MUSIC)
+                        pygame.mixer.music.play(-1)
+                    except Exception:
+                        logger.exception("Failed to play Tetris music")
                 reset_tetris()
-            elif old_state == "Tetris":
+            elif old_state == "Tetris" and SOUND_AVAILABLE:
                 pygame.mixer.music.stop()
 
     # Draw current screen


### PR DESCRIPTION
## Summary
- handle mixer init failure without crashing
- log less verbose messages by default

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846717c16a4832fa6959f239a100a7a