### PR TITLE
Enable arrow-key typing in chat

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -164,5 +164,5 @@ def draw_chat(screen, FONT, chat_lines, chat_scroll):
         x = 6 + i * 12
         screen.blit(text, (x, 98))
 
-    tip = FONT.render("ARROWS Type TAB=Shift RET=Send ESC=Back", True, (150, 150, 150))
+    tip = FONT.render("ARROWS Type TAB=Shift RET=Send ESC=Back PGUP/DN=Scroll", True, (150, 150, 150))
     screen.blit(tip, (2, 2))

--- a/main.py
+++ b/main.py
@@ -116,16 +116,18 @@ while running:
                         state = "Settings"
                     else:
                         handle_sound_event(event)
-                elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
-                    if state == "Chat":
-                        chat_scroll = 0
-                    state = "menu"
                 elif state == "Chat":
-                    # Pass arrow key events for scrolling
-                    if event.key == pygame.K_UP:
+                    if event.key == pygame.K_ESCAPE:
+                        chat_scroll = 0
+                        state = "menu"
+                    elif event.key == pygame.K_PAGEUP:
                         chat_scroll += 1
-                    elif event.key == pygame.K_DOWN:
+                    elif event.key == pygame.K_PAGEDOWN:
                         chat_scroll -= 1
+                    else:
+                        handle_chat_event(event)
+                elif event.key in [pygame.K_RETURN, pygame.K_SPACE]:
+                    state = "menu"
                 elif state == "Snake":
                     handle_snake_event(event)
                 elif state == "Pong":


### PR DESCRIPTION
## Summary
- handle chat input events so the on-screen keyboard works
- let page up/down scroll chat history and update help text

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684688430934832f999cb415d885c3d3