### PR TITLE
Fix chat line wrapping indentation

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -233,8 +233,10 @@ def draw_chat(screen, FONT, chat_lines, chat_scroll):
                     (prefix, part, prefix_color, text_color, 6)
                 )
             else:
+                # Start wrapped lines underneath the nickname rather than
+                # aligning with the text from the previous line
                 rendered_lines.append(
-                    ("", part, prefix_color, text_color, 6 + prefix_width)
+                    ("", part, prefix_color, text_color, 6)
                 )
 
     start = max(0, len(rendered_lines) - MAX_VISIBLE - chat_scroll)


### PR DESCRIPTION
## Summary
- fix chat line wrapping so wrapped lines start under the nickname

## Testing
- `python -m py_compile chat.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684693f91444832fb016602569c535d7