### PR TITLE
Fix NameError for draw_remote

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ while running:
         update_tetris(now)
         draw_tetris(screen, FONT)
     elif state == "Remote":
-        draw_remote(screen, FONT)
+        remote.draw_remote(screen, FONT)
     elif state == "Type":
         draw_type(screen, FONT)
 


### PR DESCRIPTION
## Summary
- fix call site in `main.py` to reference `remote.draw_remote`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684697a005cc832fa1bc539cd302db11