### PR TITLE
Add sound logging and tetris music

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -1,5 +1,6 @@
 import pygame
 import random
+import logging
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -15,6 +16,16 @@ player_hp = PLAYER_MAX_HP
 enemy_hp = ENEMY_MAX_HP
 message = ""
 battle_over = False
+
+# Logger used to track sound playback issues
+logger = logging.getLogger("sound")
+if not logger.handlers:
+    handler = logging.FileHandler("soundlog.txt", mode="a")
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    )
+    logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 # Move names for practice mode
 ATTACKS = ["Scratch", "Bite", "Kick", "Headbutt"]
@@ -56,8 +67,9 @@ def _play_sound(path: str) -> None:
     """Play a sound file if available."""
     try:
         pygame.mixer.Sound(path).play()
-    except Exception:
-        pass
+        logger.debug(f"Played sound: {path}")
+    except Exception as exc:
+        logger.exception(f"Failed to play {path}: {exc}")
 
 
 # Constants for wild battle UI

--- a/tetris.py
+++ b/tetris.py
@@ -1,5 +1,7 @@
 import pygame
 import random
+import logging
+import os
 
 GRID_SIZE = 8
 COLS = 10
@@ -34,6 +36,27 @@ DROP_DELAY = 0.5
 score = 0
 high_score = 0
 
+# Logger to capture all sound related events
+logger = logging.getLogger("sound")
+if not logger.handlers:
+    handler = logging.FileHandler("soundlog.txt", mode="a")
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    )
+    logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+
+
+def _start_music() -> None:
+    """Play the Tetris background music."""
+    try:
+        music_path = os.path.join("assets", "Tetris.ogg")
+        pygame.mixer.music.load(music_path)
+        pygame.mixer.music.play(-1)
+        logger.info("Playing Tetris.ogg")
+    except Exception as exc:  # pragma: no cover - runtime error logged
+        logger.exception(f"Failed to play Tetris.ogg: {exc}")
+
 
 def _new_piece():
     """Spawn a new random piece"""
@@ -57,6 +80,7 @@ def _reset_board():
 
 def reset_tetris():
     _reset_board()
+    _start_music()
 
 
 def _collision(pos, rot):
@@ -152,3 +176,4 @@ def draw_tetris(screen, FONT):
 
 # initialise first piece
 _new_piece()
+_start_music()


### PR DESCRIPTION
## Summary
- log sound events in `soundlog.txt`
- play background music in Tetris
- record successes and failures when playing sounds in battle

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68469a3a7410832f9a81bf7fe025876a