### PR TITLE
Fix Tetris music initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,6 +85,8 @@ while running:
                         init_chat()
                     elif state == "Remote":
                         remote.start_server()
+                    elif state == "Tetris":
+                        reset_tetris()
             else:
                 if state == "Type":
                     if event.key == pygame.K_ESCAPE:

--- a/tetris.py
+++ b/tetris.py
@@ -50,6 +50,8 @@ logger.setLevel(logging.DEBUG)
 def _start_music() -> None:
     """Play the Tetris background music."""
     try:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
         music_path = os.path.join("assets", "Tetris.ogg")
         pygame.mixer.music.load(music_path)
         pygame.mixer.music.play(-1)
@@ -174,6 +176,3 @@ def draw_tetris(screen, FONT):
     tip = FONT.render("Arrows Move Up Rot Enter Back", True,(200,200,200))
     screen.blit(tip,(2,114))
 
-# initialise first piece
-_new_piece()
-_start_music()


### PR DESCRIPTION
## Summary
- init pygame mixer before loading Tetris music
- start Tetris game & music when menu option is selected

## Testing
- `python -m py_compile main.py tetris.py`

------
https://chatgpt.com/codex/tasks/task_e_68469c756a84832f864b375a636530a8