### PR TITLE
Add Raspberry Pi LCD HAT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Virtual Pet for Raspberry Pi Zero 2 W
+
+This project is tailored for the [Waveshare 1.44" LCD HAT](https://www.waveshare.com/wiki/1.44inch_LCD_HAT).
+It uses the HAT's 128x128 display and built in five‑way joystick with
+three additional buttons as the sole input and output devices.
+
+The application is written with `pygame` and expects to run directly on
+the Pi's framebuffer (`/dev/fb1`).  When launched it will open a full
+screen window and listen for GPIO events from the joystick and buttons.
+
+Run the main program with:
+
+```bash
+python3 main.py
+```
+
+Ensure the environment variables `SDL_VIDEODRIVER=fbcon` and
+`SDL_FBDEV=/dev/fb1` are available (these are set automatically in
+`main.py`).
+

--- a/controller.py
+++ b/controller.py
@@ -1,3 +1,5 @@
+"""GPIO input handler for the Waveshare 1.44" LCD HAT."""
+
 import pygame
 try:
     import RPi.GPIO as GPIO

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+"""Main entry point for the virtual pet on the 1.44\" LCD HAT."""
+
+import os
 import pygame
 import sys
 import settings
@@ -33,11 +36,16 @@ from battle import (
     handle_gamelink_event,
 )
 
+# Configure pygame to use the LCD HAT's framebuffer if running on the Pi
+os.environ.setdefault("SDL_VIDEODRIVER", "fbcon")
+os.environ.setdefault("SDL_FBDEV", "/dev/fb1")
+os.environ.setdefault("SDL_NOMOUSE", "1")
+
 pygame.init()
 controller.init()
 SIZE = 128
-screen = pygame.display.set_mode((SIZE, SIZE))
-pygame.display.set_caption("Virtual Pet Menu Prototype")
+screen = pygame.display.set_mode((SIZE, SIZE), pygame.FULLSCREEN)
+pygame.display.set_caption("Virtual Pet")
 
 FONT = pygame.font.SysFont("monospace", 12)
 BIGFONT = pygame.font.SysFont("monospace", 15)
@@ -67,8 +75,6 @@ prev_state = state
 clock = pygame.time.Clock()
 running = True
 
-# For passing state (e.g. chat)
-chat_scroll = 0
 
 while running:
     prev_state = state
@@ -134,12 +140,7 @@ while running:
                         handle_sound_event(event)
                 elif state == "Chat":
                     if event.key == pygame.K_ESCAPE:
-                        chat_scroll = 0
                         state = "menu"
-                    elif event.key == pygame.K_PAGEUP:
-                        chat_scroll += 1
-                    elif event.key == pygame.K_PAGEDOWN:
-                        chat_scroll -= 1
                     else:
                         handle_chat_event(event)
                 elif state == "Inventory":
@@ -182,7 +183,7 @@ while running:
         draw_inventory(screen, FONT)
     elif state == "Chat":
         update_chat(chat_lines, now)
-        draw_chat(screen, FONT, chat_lines, chat_scroll)
+        draw_chat(screen, FONT, chat_lines, 0)
     elif state == "Settings":
         draw_settings(screen, FONT)
     elif state == "SoundSettings":


### PR DESCRIPTION
## Summary
- configure pygame for the Waveshare 1.44" LCD HAT framebuffer
- run fullscreen on the Pi and drop chat scrolling
- document new hardware requirements

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846fe004e2c832fac92b9687eeebc54