### PR TITLE
Add autostart service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,27 @@ Ensure the environment variables `SDL_VIDEODRIVER=fbcon` and
 `SDL_FBDEV=/dev/fb1` are available (these are set automatically in
 `main.py`).
 
+## Autostart on boot
+
+A `systemd` service file `virtualpet.service` is included so the
+application can start automatically when the Pi powers on.
+
+1. Copy the service file to `/etc/systemd/system`:
+
+   ```bash
+   sudo cp virtualpet.service /etc/systemd/system/
+   ```
+
+2. Edit the `WorkingDirectory` in the file if the repository is located
+   somewhere other than `/home/pi/virtualpet`.
+
+3. Enable and start the service:
+
+   ```bash
+   sudo systemctl enable virtualpet.service
+   sudo systemctl start virtualpet.service
+   ```
+
+The application will now run on every boot. View its logs with
+`journalctl -u virtualpet.service`.
+

--- a/virtualpet.service
+++ b/virtualpet.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Virtual Pet startup
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/virtualpet
+ExecStart=/usr/bin/python3 main.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a `virtualpet.service` systemd unit
- document how to enable the service so the app starts on boot

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684700154d18832fb597a0006e288e81